### PR TITLE
Yukikaze -> Haruna

### DIFF
--- a/src/bot/commands/util/eval.ts
+++ b/src/bot/commands/util/eval.ts
@@ -17,7 +17,7 @@ export default class EvalCommand extends Command {
 		super('eval', {
 			aliases: ['eval'],
 			description: {
-				content: 'Prohibit/Allow a user from using Yukikaze.',
+				content: 'Prohibit/Allow a user from using Haruna.',
 				usage: '<code>'
 			},
 			category: 'util',


### PR DESCRIPTION
In your `eval` command, it says `Yukikaze` instead of `Haruna`.